### PR TITLE
Set up Cloud dev environment + add AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+See `CLAUDE.md` for the full project overview and the (production) Docker/dokploy
+backend deployment details.
+
+## Cursor Cloud specific instructions
+
+### What runs here
+The runnable product in the Cloud VM is the **React + Vite frontend** (`src/`).
+Standard scripts are in `package.json`: `npm run dev`, `npm run build`,
+`npm run lint`, `npm run test`.
+
+The backend stack described in `CLAUDE.md` (Supabase edge functions, Postgres,
+Docker/dokploy) does **not** run in the Cloud VM — that lived on the original
+author's machine. There is no Docker or Deno here. Do not try to `docker ps`,
+deploy edge functions, or run migrations locally.
+
+### Frontend env vars (required — the app crashes without them)
+The frontend reads `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and
+`VITE_GET_PLACES_FUNCTION` via `import.meta.env`. These are provided as injected
+secrets. Two non-obvious gotchas:
+
+- If they are missing, the page renders a **blank white screen** with an
+  `Uncaught Error: supabaseClient is undefined` in the console (from
+  `src/supabaseClient.ts`).
+- A dev server started inside a fresh `tmux`/login shell may **not inherit** the
+  injected secret env vars. The reliable fix is a gitignored `.env` file at the
+  repo root containing those three `VITE_*` values (Vite always loads `.env`
+  regardless of shell). Create it from the injected env before `npm run dev`:
+  ```bash
+  { echo "VITE_SUPABASE_URL=$VITE_SUPABASE_URL"; \
+    echo "VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY"; \
+    echo "VITE_GET_PLACES_FUNCTION=$VITE_GET_PLACES_FUNCTION"; } > .env
+  ```
+
+### Backend connectivity
+`VITE_SUPABASE_URL` points at the live self-hosted backend (the public domain
+noted in `CLAUDE.md`), which **is reachable from the Cloud VM**. So the
+city search (weather/sky conditions via `get-conditions`) and the nearby
+"Dark Sky Places" list (`get-places`) work end-to-end against real data. Kong
+requires the `apikey` header; the frontend sends it automatically.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for the Moongaz.ing frontend in Cursor Cloud, and documents the non-obvious startup caveats.

- Verified the full dev workflow works: `npm install`, `npm run lint`, `npm run test` (115 tests), `npm run build`, and `npm run dev`.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering:
  - Only the React + Vite frontend runs in the Cloud VM (no Docker/Deno/backend here).
  - The app crashes to a blank screen without `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` / `VITE_GET_PLACES_FUNCTION`; a fresh tmux/login shell may not inherit injected secrets, so create a gitignored `.env` from them before `npm run dev`.
  - The injected `VITE_SUPABASE_URL` points at the live self-hosted backend, which is reachable from the VM, so search works end-to-end.

## Walkthrough
Home page loads with the live moon phase, and searching a city returns real conditions + nearby Dark Sky Places.

[moongazing_search_flagstaff_demo.mp4](https://cursor.com/agents/bc-3408000f-adad-4a35-ac6c-a296b716ba8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoongazing_search_flagstaff_demo.mp4)

[Home page loaded](https://cursor.com/agents/bc-3408000f-adad-4a35-ac6c-a296b716ba8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoongazing_home_loaded.webp)
[Search results for Flagstaff, AZ](https://cursor.com/agents/bc-3408000f-adad-4a35-ac6c-a296b716ba8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoongazing_results_flagstaff.webp)

## Testing
- `npm run lint` — pass
- `npm run test` — 115 passed
- `npm run build` — pass
- `npm run dev` — app renders and search works end-to-end (see video)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3408000f-adad-4a35-ac6c-a296b716ba8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3408000f-adad-4a35-ac6c-a296b716ba8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

